### PR TITLE
Add "delay" before playing music option

### DIFF
--- a/include/js/player.js
+++ b/include/js/player.js
@@ -11,7 +11,9 @@ let settings = localStorage.settings ? JSON.parse(localStorage.settings) : {
   "theme_color" : "red",
   "play_music_when_alive" : "false",
   "alive_volume" : 0.1,
-  "master_volume" : 0.8
+  "master_volume" : 0.8,
+  "delay_music_on_death" : "false",
+  "delay_amount" : 1.5
 };
 
 let playlist = localStorage.playlist ? JSON.parse(localStorage.playlist) : [];
@@ -248,13 +250,15 @@ function pullUpdate () {
   if (shouldPlay === false) {
     if (!JSON.parse(settings.play_music_when_alive)){
       player.pause();
-    }else{
-      player.play();
-      player.volume = settings.alive_volume;
+    } else {
+	    player.play();
+	    player.volume = settings.alive_volume;
     }
   } else {
+    player.setTimeOut(function (){
     player.play();
     player.volume = settings.master_volume;
+    }, settings.delay_amount*1000);
   }
 }
 

--- a/include/js/player.js
+++ b/include/js/player.js
@@ -256,8 +256,8 @@ function pullUpdate () {
     }
   } else {
     player.setTimeOut(function (){
-    player.play();
-    player.volume = settings.master_volume;
+      player.play();
+      player.volume = settings.master_volume;
     }, settings.delay_amount*1000);
   }
 }

--- a/index.html
+++ b/index.html
@@ -83,6 +83,41 @@
                   </li>
                 </ul>
               </div>
+              <div class="content-block-title">Delay Music Before Playing</div>
+              <div class="list-block">
+                <ul>
+                    <label class="label-radio item-content">
+                      <input type="radio" name="delay_music_on_death" value="false" checked="checked">
+                      <div class="item-media"><i class="icon icon-form-radio"></i></div>
+                      <div class="item-inner">
+                        <div class="item-title">Default (None)</div>
+                      </div>
+                    </label>
+                  </li>
+                  <li>
+                    <label class="label-radio item-content">
+                      <input type="radio" name="delay_music_on_death" value="true">
+                      <div class="item-media"><i class="icon icon-form-radio"></i></div>
+                      <div class="item-inner">
+                        <div class="item-title">Custom Delay (0-4s)</div>
+                      </div>
+                    </label>
+                  </li>
+                  <li>
+                    <div class="item-content">
+                      <div class="item-media"><i class="fa fa-clock-o" aria-hidden="true"></i></div>
+                      <div class="item-inner">
+                        <div class="item-input">
+                          <div class="range-slider">
+                            <input id="delay_slider" name="delay_amount" type="range" min="0" max="4" value="1.5" step="0.5" class="">
+                          </div>
+                        </div>
+                      </div>
+                      <div class="item-media"><i class="fa fa-clock-o fa-lg" aria-hidden="true"></i></div>
+                    </div>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR aims to implement the delay after death before music starts playing so players can listen for extra info (footsteps etc) on their deathcam.